### PR TITLE
Trimmed down dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ categories  = ["data-structures", "mathematics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num   = "0.4"
+num-traits = "0.2"
+
+[dev-dependencies]
 paste = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ keywords    = ["bitset", "small-values", "allocation-free"]
 categories  = ["data-structures", "mathematics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+alloc = []
+default = ["alloc"]
+
 [dependencies]
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 paste = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{ops::{Shl, ShlAssign}, fmt::Debug};
 
-use num::{PrimInt, Unsigned};
+use num_traits::{PrimInt, Unsigned};
 
 #[macro_export]
 macro_rules! bitset {
@@ -496,8 +496,8 @@ bitset!(Set256, 256, 128, u128);
 
 macro_rules! test {
     ($name: ident, $capa: expr) => {
+        #[cfg(test)]
         paste::paste! {
-            #[cfg(test)]
             mod [<test_ $name:snake:lower>] {
                 use super::*;
 
@@ -1365,6 +1365,17 @@ macro_rules! test {
         }
     };
 }
+
+//#[cfg(test)]
+//mod tests{
+//    use super::*;
+//    test!(Set8,     8);
+//    test!(Set16,   16);
+//    test!(Set32,   32);
+//    test!(Set64,   64);
+//    test!(Set128, 128);
+//    test!(Set256, 256);
+//}
 
 test!(Set8,     8);
 test!(Set16,   16);


### PR DESCRIPTION
Hi,

Thanks for writing this nice library. I noticed that you depend on the entire `num` crate despite only using the `num-traits` part, so I updated it to depend directly on `num-traits`. While I was at it I also changed `paste` into a `dev-dependency` and added `no_std` support.